### PR TITLE
Allow OmniAuth OpenID provider taking :login_entrypoint as an option.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'guard'
   gem 'guard-rspec'
   gem 'growl'
-  gem 'rb-fsevent'
+  gem 'rb-fsevent', '~> 0.9'
 end
 
 group :example do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 PATH
   remote: .
   specs:
-    omniauth-openid (1.0.0.beta1)
-      omniauth (~> 1.0.0.beta1)
+    omniauth-openid (1.0.1)
+      omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
 
 GEM
@@ -22,11 +22,11 @@ GEM
       thor (~> 0.14.6)
     guard-rspec (0.5.0)
       guard (>= 0.8.4)
-    hashie (1.2.0)
+    hashie (3.4.1)
     multi_json (1.0.3)
-    omniauth (1.0.0.pr2)
-      hashie
-      rack
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
     rack (1.3.5)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
@@ -36,7 +36,7 @@ GEM
     rack-test (0.6.1)
       rack (>= 1.0)
     rake (0.9.2)
-    rb-fsevent (0.4.3.1)
+    rb-fsevent (0.9.4)
     rdiscount (1.6.8)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
@@ -57,7 +57,7 @@ GEM
     thor (0.14.6)
     tilt (1.3.3)
     webmock (1.7.7)
-      addressable (> 2.2.5, ~> 2.2)
+      addressable (~> 2.2, > 2.2.5)
       crack (>= 0.1.7)
     yard (0.7.2)
 
@@ -72,9 +72,9 @@ DEPENDENCIES
   omniauth-openid!
   rack-test (~> 0.5)
   rake (~> 0.8)
-  rb-fsevent
+  rb-fsevent (~> 0.9)
   rdiscount (~> 1.6)
-  rspec (~> 2.5)
+  rspec (~> 2.7)
   ruby-openid (= 2.1.8)!
   simplecov (~> 0.4)
   sinatra

--- a/lib/omniauth/strategies/open_id.rb
+++ b/lib/omniauth/strategies/open_id.rb
@@ -27,7 +27,7 @@ module OmniAuth
       option :store, ::OpenID::Store::Memory.new
       option :identifier, nil
       option :identifier_param, 'openid_url'
-      option :login_entrypoint
+      option :on_login, nil
 
       def dummy_app
         lambda{|env| [401, {"WWW-Authenticate" => Rack::OpenID.build_header(
@@ -68,8 +68,8 @@ module OmniAuth
       end
 
       def get_identifier
-        if options[:login_entrypoint].respond_to?(:call)
-          instance_eval &options[:login_entrypoint]
+        if options[:on_login].respond_to?(:call)
+          instance_eval &options[:on_login]
         else
           openid_form
         end

--- a/lib/omniauth/strategies/open_id.rb
+++ b/lib/omniauth/strategies/open_id.rb
@@ -69,7 +69,7 @@ module OmniAuth
 
       def get_identifier
         if options[:on_login].respond_to?(:call)
-          instance_eval &options[:on_login]
+          options[:on_login].call(env)
         else
           openid_form
         end

--- a/spec/omniauth/strategies/open_id_spec.rb
+++ b/spec/omniauth/strategies/open_id_spec.rb
@@ -96,7 +96,7 @@ describe OmniAuth::Strategies::OpenID, :type => :strategy do
         use Rack::Session::Cookie
 
         use OmniAuth::Builder do
-          provider :openid, :login_entrypoint => ->(env){ [302, {}, ['Awesome']] }
+          provider :openid, :on_login => ->(env){ [302, {}, ['Awesome']] }
         end
 
         run lambda {|env| [404, {'Content-Type' => 'text/plain'}, [nil || env.key?('omniauth.auth').to_s]] }

--- a/spec/omniauth/strategies/open_id_spec.rb
+++ b/spec/omniauth/strategies/open_id_spec.rb
@@ -3,89 +3,122 @@ require 'rack/openid'
 require 'omniauth-openid'
 
 describe OmniAuth::Strategies::OpenID, :type => :strategy do
-  def app
-    strat = OmniAuth::Strategies::OpenID
-    Rack::Builder.new {
-      use Rack::Session::Cookie
-      use strat
-      run lambda {|env| [404, {'Content-Type' => 'text/plain'}, [nil || env.key?('omniauth.auth').to_s]] }
-    }.to_app
-  end
-
-  def expired_query_string
-    'openid=consumer&janrain_nonce=2011-07-21T20%3A14%3A56ZJ8LP3T&openid.assoc_handle=%7BHMAC-SHA1%7D%7B4e284c39%7D%7B9nvQeg%3D%3D%7D&openid.claimed_id=http%3A%2F%2Flocalhost%3A1123%2Fjohn.doe%3Fopenid.success%3Dtrue&openid.identity=http%3A%2F%2Flocalhost%3A1123%2Fjohn.doe%3Fopenid.success%3Dtrue&openid.mode=id_res&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.op_endpoint=http%3A%2F%2Flocalhost%3A1123%2Fserver%2F%3Fopenid.success%3Dtrue&openid.response_nonce=2011-07-21T20%3A14%3A56Zf9gC8S&openid.return_to=http%3A%2F%2Flocalhost%3A8888%2FDevelopment%2FWordpress%2Fwp_openid%2F%3Fopenid%3Dconsumer%26janrain_nonce%3D2011-07-21T20%253A14%253A56ZJ8LP3T&openid.sig=GufV13SUJt8VgmSZ92jGZCFBEvQ%3D&openid.signed=assoc_handle%2Cclaimed_id%2Cidentity%2Cmode%2Cns%2Cop_endpoint%2Cresponse_nonce%2Creturn_to%2Csigned'
-  end
-
-  describe '/auth/open_id without an identifier URL' do
-    before do
-      get '/auth/open_id'
+  context "standard OpenID Login" do
+    def app
+      strat = OmniAuth::Strategies::OpenID
+      Rack::Builder.new {
+        use Rack::Session::Cookie
+        use strat
+        run lambda {|env| [404, {'Content-Type' => 'text/plain'}, [nil || env.key?('omniauth.auth').to_s]] }
+      }.to_app
     end
 
-    it 'should respond with OK' do
-      last_response.should be_ok
+    def expired_query_string
+      'openid=consumer&janrain_nonce=2011-07-21T20%3A14%3A56ZJ8LP3T&openid.assoc_handle=%7BHMAC-SHA1%7D%7B4e284c39%7D%7B9nvQeg%3D%3D%7D&openid.claimed_id=http%3A%2F%2Flocalhost%3A1123%2Fjohn.doe%3Fopenid.success%3Dtrue&openid.identity=http%3A%2F%2Flocalhost%3A1123%2Fjohn.doe%3Fopenid.success%3Dtrue&openid.mode=id_res&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.op_endpoint=http%3A%2F%2Flocalhost%3A1123%2Fserver%2F%3Fopenid.success%3Dtrue&openid.response_nonce=2011-07-21T20%3A14%3A56Zf9gC8S&openid.return_to=http%3A%2F%2Flocalhost%3A8888%2FDevelopment%2FWordpress%2Fwp_openid%2F%3Fopenid%3Dconsumer%26janrain_nonce%3D2011-07-21T20%253A14%253A56ZJ8LP3T&openid.sig=GufV13SUJt8VgmSZ92jGZCFBEvQ%3D&openid.signed=assoc_handle%2Cclaimed_id%2Cidentity%2Cmode%2Cns%2Cop_endpoint%2Cresponse_nonce%2Creturn_to%2Csigned'
     end
 
-    it 'should respond with HTML' do
-      last_response.content_type.should == 'text/html'
+    describe '/auth/open_id without an identifier URL' do
+      before do
+        get '/auth/open_id'
+      end
+
+      it 'should respond with OK' do
+        last_response.should be_ok
+      end
+
+      it 'should respond with HTML' do
+        last_response.content_type.should == 'text/html'
+      end
+
+      it 'should render an identifier URL input' do
+        last_response.body.should =~ %r{<input[^>]*openid_url}
+      end
     end
 
-    it 'should render an identifier URL input' do
-      last_response.body.should =~ %r{<input[^>]*openid_url}
-    end
-  end
+    #describe '/auth/open_id with an identifier URL' do
+    #  context 'successful' do
+    #    before do
+    #      @identifier_url = 'http://me.example.org'
+    #      # TODO: change this mock to actually return some sort of OpenID response
+    #      stub_request(:get, @identifier_url)
+    #      get '/auth/open_id?openid_url=' + @identifier_url
+    #    end
+    #
+    #    it 'should redirect to the OpenID identity URL' do
+    #      last_response.should be_redirect
+    #      last_response.headers['Location'].should =~ %r{^#{@identifier_url}.*}
+    #    end
+    #
+    #    it 'should tell the OpenID server to return to the callback URL' do
+    #      return_to = CGI.escape(last_request.url + '/callback')
+    #      last_response.headers['Location'].should =~ %r{[\?&]openid.return_to=#{return_to}}
+    #    end
+    #  end
+    #end
 
-  #describe '/auth/open_id with an identifier URL' do
-  #  context 'successful' do
-  #    before do
-  #      @identifier_url = 'http://me.example.org'
-  #      # TODO: change this mock to actually return some sort of OpenID response
-  #      stub_request(:get, @identifier_url)
-  #      get '/auth/open_id?openid_url=' + @identifier_url
-  #    end
-  #  
-  #    it 'should redirect to the OpenID identity URL' do
-  #      last_response.should be_redirect
-  #      last_response.headers['Location'].should =~ %r{^#{@identifier_url}.*}
-  #    end
-  #  
-  #    it 'should tell the OpenID server to return to the callback URL' do
-  #      return_to = CGI.escape(last_request.url + '/callback')
-  #      last_response.headers['Location'].should =~ %r{[\?&]openid.return_to=#{return_to}}
-  #    end
-  #  end 
-  #end
+    describe 'followed by /auth/open_id/callback' do
+      context 'successful' do
+        #before do
+        #  @identifier_url = 'http://me.example.org'
+        #  # TODO: change this mock to actually return some sort of OpenID response
+        #  stub_request(:get, @identifier_url)
+        #  get '/auth/open_id/callback'
+        #end
 
-  describe 'followed by /auth/open_id/callback' do
-    context 'successful' do
-      #before do
-      #  @identifier_url = 'http://me.example.org'
-      #  # TODO: change this mock to actually return some sort of OpenID response
-      #  stub_request(:get, @identifier_url)
-      #  get '/auth/open_id/callback'
-      #end
+        it "should set provider to open_id"
+        it "should create auth_hash based on sreg"
+        it "should create auth_hash based on ax"
 
-      it "should set provider to open_id"
-      it "should create auth_hash based on sreg"
-      it "should create auth_hash based on ax"
+        #it 'should call through to the master app' do
+        #  last_response.body.should == 'true'
+        #end
+      end
 
-      #it 'should call through to the master app' do
-      #  last_response.body.should == 'true'
-      #end
-    end
+      context 'unsuccessful' do
+        describe 'returning with expired credentials' do
+          before do
+            # get '/auth/open_id/callback?' + expired_query_string
+          end
 
-    context 'unsuccessful' do
-      describe 'returning with expired credentials' do
-        before do
-          # get '/auth/open_id/callback?' + expired_query_string
-        end
-
-        it 'it should redirect to invalid credentials' do
-          pending
-          last_response.should be_redirect
-          last_response.headers['Location'].should =~ %r{invalid_credentials}
+          it 'it should redirect to invalid credentials' do
+            pending
+            last_response.should be_redirect
+            last_response.headers['Location'].should =~ %r{invalid_credentials}
+          end
         end
       end
     end
   end
 
+  context "when login entrypoint is setup" do
+    def app
+      Rack::Builder.new do
+        use Rack::Session::Cookie
+
+        use OmniAuth::Builder do
+          provider :openid, :login_entrypoint => ->(env){ [302, {}, ['Awesome']] }
+        end
+
+        run lambda {|env| [404, {'Content-Type' => 'text/plain'}, [nil || env.key?('omniauth.auth').to_s]] }
+      end.to_app
+    end
+
+    describe '/auth/open_id without an identifier URL' do
+      before do
+        get '/auth/open_id'
+      end
+
+      it 'should respond with OK' do
+        last_response.should be_redirect
+      end
+
+      it 'should respond with HTML' do
+        last_response.content_type.should == 'text/html'
+      end
+
+      it 'should render an identifier URL input' do
+        last_response.body.should == 'Awesome'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change will allow developer to specify the login entrypoint other than using the default OpenID login form, as what is shown below.

``` ruby
  provider :open_id, :login_on => ->(env){
    if request.get?
      response = Rack::Response.new
      response.redirect YOUR_LOGIN_PAGE
      response.finish
    end
  }
```
